### PR TITLE
Fixed a bug that prevented the PowerSwitch device from toggling

### DIFF
--- a/tplink-smartplug.coffee
+++ b/tplink-smartplug.coffee
@@ -118,7 +118,7 @@ module.exports = (env) ->
       @requestPromise = Promise.resolve(@plugInstance.getPowerState()).then((powerState) =>
         env.logger.debug "state is #{powerState}"
         @_setState powerState
-        #return Promise.resolve @_state
+        return Promise.resolve @_state
       ).catch((error) =>
         env.logger.error("Unable to get power state of device: " + error.toString())
         #return Promise.reject


### PR DESCRIPTION
Fixed bug: The device was not able to be toggled properly, e. g. in a Pimatic Rule ("When ... then toggle ...").
