### PR TITLE
Update tplink-smartplug.coffee

### DIFF
--- a/tplink-smartplug.coffee
+++ b/tplink-smartplug.coffee
@@ -134,7 +134,7 @@ module.exports = (env) ->
         return Promise.resolve @_state
       ).catch((error) =>
         msg = "Unable to get power state of device: " + error.toString()
-        env.logger.error(msg)
+        env.logger.warn(msg)
         Promise.reject msg
       ) 
 
@@ -145,7 +145,7 @@ module.exports = (env) ->
         @_setState(state)
       ).catch((error) =>
         msg = "Unable to set power state of device: " + error.toString()
-        env.logger.error(msg)
+        env.logger.warn(msg)
         Promise.reject msg
       ) 
       
@@ -216,7 +216,7 @@ module.exports = (env) ->
         Promise.resolve()
       ).catch((error) =>
         msg = "Unable to get consumption of device: " + error.toString()
-        env.logger.error(msg)
+        env.logger.warn(msg)
         Promise.reject msg
       ) 
       


### PR DESCRIPTION
Changed env.logger.error to env.looger.warn for power state and consumption.

Basing on this finding reported in [Pimatic forum](https://forum.pimatic.org/topic/2211/new-plugin-for-tp-link-smartplugs-hs100-and-hs110/73).